### PR TITLE
feat(standings): integrate league championship and standings into the…

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -6,15 +6,17 @@ import JsonLd from '@/components/json-ld'
 import { organizationSchema } from '@/lib/schema'
 import TeamPhotoStrip from '@/components/team-photo-strip'
 import UpcomingEvents from '@/components/upcoming-events'
+import LeagueTable from '@/components/league-table'
 import { ogImage } from '@/lib/og'
 import { getPracticeSchedule } from '@/lib/practice-schedule'
-import { features } from '@/lib/features'
 import { client } from '@/sanity/lib/client'
 import {
     matchesQuery,
     practicesQuery,
+    teamsQuery,
     type SanityMatch,
     type SanityPractice,
+    type SanityTeam,
 } from '@/sanity/lib/queries'
 
 export const revalidate = 3600
@@ -35,16 +37,16 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Home() {
-    const showCalendar = features.homepageCalendar
-
-    const [schedule, matches, practices]: [
+    const [schedule, matches, practices, teams]: [
         Awaited<ReturnType<typeof getPracticeSchedule>>,
         SanityMatch[],
         SanityPractice[],
+        SanityTeam[],
     ] = await Promise.all([
         getPracticeSchedule(),
-        showCalendar ? client.fetch(matchesQuery) : Promise.resolve([] as SanityMatch[]),
-        showCalendar ? client.fetch(practicesQuery) : Promise.resolve([] as SanityPractice[]),
+        client.fetch(matchesQuery),
+        client.fetch(practicesQuery),
+        client.fetch(teamsQuery),
     ])
 
     return (
@@ -56,13 +58,10 @@ export default async function Home() {
             <section className="bg-white py-16">
                 <div className="px-4 sm:px-6 lg:px-32">
                     <div className="flex flex-col lg:flex-row gap-8 lg:items-start lg:justify-between">
-                        {/*
-                          League table widget — placeholder for next iteration.
-                          Will live in this column once built.
-                          <div className="hidden lg:block w-96 shrink-0">
-                              <LeagueTable />
-                          </div>
-                        */}
+                        {/* League standings (compact) — desktop only */}
+                        <div className="hidden lg:block w-96 shrink-0">
+                            <LeagueTable variant="compact" />
+                        </div>
 
                         {/* Centered hero text + CTAs (matches the original section layout) */}
                         <div className="flex-1 flex justify-center">
@@ -100,12 +99,10 @@ export default async function Home() {
                             </div>
                         </div>
 
-                        {/* Upcoming events widget — desktop only, gated by feature flag */}
-                        {showCalendar && (
-                            <div className="hidden lg:block w-96 shrink-0">
-                                <UpcomingEvents matches={matches} practices={practices} />
-                            </div>
-                        )}
+                        {/* Upcoming events widget — desktop only */}
+                        <div className="hidden lg:block w-96 shrink-0">
+                            <UpcomingEvents matches={matches} practices={practices} teams={teams} />
+                        </div>
                     </div>
                 </div>
             </section>
@@ -118,14 +115,19 @@ export default async function Home() {
                 <TeamPhotoStrip count={6} />
             </section>
 
-            {/* Mobile-only upcoming events placement — gated by feature flag */}
-            {showCalendar && (
-                <section className="lg:hidden px-4 mb-12">
-                    <div className="max-w-sm mx-auto">
-                        <UpcomingEvents matches={matches} practices={practices} />
-                    </div>
-                </section>
-            )}
+            {/* Mobile-only upcoming events placement */}
+            <section className="lg:hidden px-4 mb-12">
+                <div className="max-w-sm mx-auto">
+                    <UpcomingEvents matches={matches} practices={practices} teams={teams} />
+                </div>
+            </section>
+
+            {/* Mobile-only league table placement — full variant since vertical scroll handles overflow */}
+            <section className="lg:hidden px-4 mb-12">
+                <div className="max-w-2xl mx-auto">
+                    <LeagueTable variant="full" />
+                </div>
+            </section>
 
             <InstagramFeed />
 

--- a/app/(site)/results/[season]/page.tsx
+++ b/app/(site)/results/[season]/page.tsx
@@ -5,6 +5,8 @@ import { client } from '@/sanity/lib/client'
 import { matchesQuery, teamsQuery, type SanityMatch, type SanityTeam } from '@/sanity/lib/queries'
 import JsonLd from '@/components/json-ld'
 import Breadcrumbs from '@/components/breadcrumbs'
+import LeagueTable from '@/components/league-table'
+import PlayoffBracket from '@/components/playoff-bracket'
 import {
     breadcrumbSchema,
     formatMatchDateLong,
@@ -91,6 +93,8 @@ export default async function SeasonPage({ params }: Params) {
 
     const played = wins + losses + draws
     const label = seasonLabel(seasonNum)
+    // Full-format label "YYYY-YYYY" used as the lookup key for league standings docs.
+    const fullSeasonLabel = `${seasonNum - 1}-${seasonNum}`
 
     const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '')
     function findTeam(name: string): SanityTeam | null {
@@ -132,9 +136,35 @@ export default async function SeasonPage({ params }: Params) {
                 </p>
                 <h1 className="text-5xl md:text-6xl font-claymore text-[#111111] mb-3">{label} Season</h1>
                 <div className="w-12 h-px bg-[#fd80b5] mx-auto mb-4" />
-                <p className="text-[#555555] max-w-2xl mx-auto">
+                <p className="text-[#555555] max-w-2xl mx-auto mb-6">
                     Match-by-match results for the Central Florida Claymores RFC in the {label} Florida Rugby Union season.
                 </p>
+
+                {/* Season selector — newest first */}
+                {allSeasons.length > 1 && (
+                    <nav
+                        aria-label="Select a season"
+                        className="flex flex-wrap gap-2 justify-center max-w-3xl mx-auto"
+                    >
+                        {[...allSeasons].reverse().map((s) => {
+                            const isCurrent = s === seasonNum
+                            return (
+                                <Link
+                                    key={s}
+                                    href={`/results/${s}`}
+                                    aria-current={isCurrent ? 'page' : undefined}
+                                    className={`text-xs font-semibold uppercase tracking-widest px-3 py-1.5 rounded-full border transition-colors ${
+                                        isCurrent
+                                            ? 'bg-[#77c3ef] text-white border-[#77c3ef]'
+                                            : 'bg-white text-[#555555] border-[#EAEAEA] hover:border-[#77c3ef] hover:text-[#77c3ef]'
+                                    }`}
+                                >
+                                    {seasonLabel(s)}
+                                </Link>
+                            )
+                        })}
+                    </nav>
+                )}
             </div>
 
             {/* Stats */}
@@ -153,6 +183,17 @@ export default async function SeasonPage({ params }: Params) {
                     </div>
                 ))}
             </div>
+
+            {/* League standings — full table. Renders a fallback when no doc exists for this season. */}
+            <section className="mb-10" aria-labelledby="season-standings-heading">
+                <h2 id="season-standings-heading" className="text-xl font-claymore text-[#111111] mb-4">
+                    Florida Rugby Union Standings
+                </h2>
+                <LeagueTable seasonLabel={fullSeasonLabel} variant="full" />
+            </section>
+
+            {/* Playoff bracket — renders only when the season has playoff matches stored. */}
+            <PlayoffBracket seasonLabel={fullSeasonLabel} className="mb-10" />
 
             {/* Match list */}
             <div className="border border-[#EAEAEA] rounded-xl overflow-hidden divide-y divide-[#EAEAEA]">

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -25,6 +25,10 @@ export async function POST(req: NextRequest) {
     } else if (type === 'practiceSchedule') {
         // Schedule appears in copy/schema on virtually every page — revalidate everything.
         revalidatePath('/', 'layout')
+    } else if (type === 'leagueStandings' || type === 'leagueChampionship') {
+        // Standings render on the homepage (left rail) and /results/[season].
+        revalidatePath('/')
+        revalidatePath('/results/[season]', 'page')
     } else {
         // Fallback: revalidate everything
         revalidatePath('/', 'layout')

--- a/app/api/scrape-rugby/route.ts
+++ b/app/api/scrape-rugby/route.ts
@@ -214,27 +214,22 @@ export async function GET(request: Request) {
         matches.map(m => {
           const existingDoc = existingByDate.get(m.date)
           if (existingDoc) {
-            // Manual override: editor has locked this doc — leave it completely alone
-            if (existingDoc.manualOverride) {
-              skippedLocked++
-              return Promise.resolve({ skipped: 'locked' as const })
-            }
-            // If already played and scores are set, preserve them (manual edits protected)
-            const scoresAlreadySet = existingDoc.status === 'played' &&
-              (existingDoc.homeScore != null || existingDoc.awayScore != null)
-            return sanity.patch(existingDoc._id).set({
-              homeTeam: m.homeTeam,
-              awayTeam: m.awayTeam,
-              status: m.status,
-              season: m.season,
-              matchType: m.matchType,
-              ...(scoresAlreadySet ? {} : { homeScore: m.homeScore, awayScore: m.awayScore }),
-              ...(m.competition ? { competition: m.competition } : {}),
-              ...(m.note ? { note: m.note } : {}),
-            }).commit()
+            // Existing match docs are NEVER updated by the scraper. They may
+            // have been hand-cleaned in Studio — preserve those edits in full.
+            // To re-scrape one, delete the doc in Studio and let the next run
+            // recreate it. `manualOverride` is no longer strictly needed (this
+            // skip is unconditional) but we keep the field/flag for clarity.
+            skippedLocked++
+            return Promise.resolve({ skipped: 'preserved' as const })
           }
-          // New match — create with scraped id and register in map for this run
-          existingByDate.set(m.date, { _id: m._id, status: m.status, homeScore: m.homeScore, awayScore: m.awayScore, manualOverride: false })
+          // New match — create with scraped id and register in map for this run.
+          existingByDate.set(m.date, {
+            _id: m._id,
+            status: m.status,
+            homeScore: m.homeScore,
+            awayScore: m.awayScore,
+            manualOverride: false,
+          })
           return sanity.createOrReplace(m)
         })
       )

--- a/app/api/scrape-standings/route.ts
+++ b/app/api/scrape-standings/route.ts
@@ -1,0 +1,570 @@
+import * as cheerio from 'cheerio'
+import { createClient } from '@sanity/client'
+
+// Columns we pull from the rugbyfl.com "Championship_Print.asp" standings table.
+// The table has 19 columns including a leading "Pos" (always 0) and per-team
+// tries/conversions/cards we don't surface. Order in source HTML:
+//
+//  0  Pos
+//  1  Pool          <- keep
+//  2  Team          <- keep (anchor text)
+//  3  Played        <- keep
+//  4  Won           <- keep
+//  5  Lost          <- keep
+//  6  Drawn         <- keep
+//  7  Tries For
+//  8  Conversions
+//  9  Penalty Kicks
+//  10 Drop Goals
+//  11 Points Favor   <- keep
+//  12 Points Against <- keep
+//  13 Points Diff    <- keep
+//  14 Yellow Cards
+//  15 Red Cards
+//  16 Points
+//  17 Bonus Points   <- keep
+//  18 Total Points   <- keep (sort key)
+
+interface ScrapedRow {
+    teamName: string
+    pool: string
+    played: number
+    won: number
+    lost: number
+    drawn: number
+    pointsFor: number
+    pointsAgainst: number
+    pointsDifference: number
+    bonusPoints: number
+    totalPoints: number
+}
+
+function toInt(text: string | undefined): number {
+    if (!text) return 0
+    const n = parseInt(text.replace(/\u00a0/g, '').trim(), 10)
+    return Number.isFinite(n) ? n : 0
+}
+
+function parseStandings(html: string): ScrapedRow[] {
+    const $ = cheerio.load(html)
+    const rows: ScrapedRow[] = []
+
+    // Find the standings table: the one whose header row mentions our expected columns.
+    const tables = $('table').toArray()
+    const standingsTable = tables.find((table) => {
+        const headerText = $(table).find('tr').first().text().toLowerCase()
+        return (
+            headerText.includes('pos') &&
+            headerText.includes('pool') &&
+            headerText.includes('team') &&
+            headerText.includes('played') &&
+            headerText.includes('total points')
+        )
+    })
+
+    if (!standingsTable) return rows
+
+    $(standingsTable).find('tr').each((_i, tr) => {
+        const cells = $(tr).find('td')
+        if (cells.length < 19) return
+
+        const teamAnchor = cells.eq(2).find('a').first()
+        const teamName = (teamAnchor.text() || cells.eq(2).text())
+            .replace(/\u00a0/g, '')
+            .replace(/\s+/g, ' ')
+            .trim()
+        if (!teamName || teamName.toLowerCase() === 'team') return
+
+        rows.push({
+            teamName,
+            pool: cells.eq(1).text().trim(),
+            played: toInt(cells.eq(3).text()),
+            won: toInt(cells.eq(4).text()),
+            lost: toInt(cells.eq(5).text()),
+            drawn: toInt(cells.eq(6).text()),
+            pointsFor: toInt(cells.eq(11).text()),
+            pointsAgainst: toInt(cells.eq(12).text()),
+            pointsDifference: toInt(cells.eq(13).text()),
+            bonusPoints: toInt(cells.eq(17).text()),
+            totalPoints: toInt(cells.eq(18).text()),
+        })
+    })
+
+    return rows
+}
+
+// ── Fallback: compute standings from the schedule table on the same page ────
+//
+// Older championships often have "Standings are not available at this time."
+// but a fully populated schedule. Each match row carries the per-team total
+// points (TP) and bonus points (BP) — summing those gives us a valid table.
+
+interface ScheduleMatch {
+    date: string // ISO date YYYY-MM-DD if parseable, otherwise ''
+    homeName: string
+    awayName: string
+    homeScore: number | null
+    awayScore: number | null
+    homeTries: number
+    awayTries: number
+    note: string
+}
+
+function parseScheduleMatches(html: string): ScheduleMatch[] {
+    const $ = cheerio.load(html)
+    const out: ScheduleMatch[] = []
+
+    // Find the schedule table by header signature.
+    const tables = $('table').toArray()
+    const scheduleTable = tables.find((table) => {
+        const headerText = $(table).find('tr').first().text().toLowerCase()
+        return (
+            headerText.includes('date') &&
+            headerText.includes('home') &&
+            headerText.includes('tries') &&
+            headerText.includes('away') &&
+            // Both BP and TP columns — distinguishes schedule from any other table.
+            (headerText.match(/bp/g) ?? []).length >= 2
+        )
+    })
+
+    if (!scheduleTable) return out
+
+    const trs = $(scheduleTable).find('tr').toArray()
+    for (let i = 0; i < trs.length; i++) {
+        const tr = trs[i]
+        const cells = $(tr).find('td')
+        // Match row has 14 cells: Date | Home | (Score) | Tries | P | BP | TP | <spacer> | Away | (Score) | Tries | P | BP | TP
+        if (cells.length < 14) continue
+
+        const homeName = stripWhitespace(cells.eq(1).find('a').text() || cells.eq(1).text())
+        const awayName = stripWhitespace(cells.eq(8).find('a').text() || cells.eq(8).text())
+        if (!homeName || !awayName) continue
+        if (homeName.toLowerCase() === 'home' && awayName.toLowerCase() === 'away') continue // header
+
+        // Scores: rugbyfl wraps played scores in parens like "(31)". Unplayed games have a bare "0".
+        const homeScore = parseScoreCell(cells.eq(2).text())
+        const awayScore = parseScoreCell(cells.eq(9).text())
+
+        // Look at the next row for an attached note. Notes are colspan rows that
+        // render as 2 cells in cheerio (the leading spacer + the note body).
+        let note = ''
+        if (i + 1 < trs.length) {
+            const nextCells = $(trs[i + 1]).find('td')
+            if (nextCells.length <= 2) {
+                const nextText = nextCells.text().trim()
+                if (/note:?/i.test(nextText)) {
+                    note = nextText.replace(/^[\s\u00a0]*note:?\s*/i, '').trim()
+                }
+            }
+        }
+
+        out.push({
+            date: parseScheduleDate(cells.eq(0).text()),
+            homeName,
+            awayName,
+            homeScore,
+            awayScore,
+            homeTries: toInt(cells.eq(3).text()),
+            awayTries: toInt(cells.eq(10).text()),
+            note,
+        })
+    }
+
+    return out
+}
+
+function stripWhitespace(s: string): string {
+    return s.replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+// "(31)" → 31, "0" → null (unplayed), "" → null
+function parseScoreCell(raw: string): number | null {
+    const m = raw.replace(/\u00a0/g, ' ').trim().match(/^\((-?\d+)\)$/)
+    if (!m) return null
+    const n = parseInt(m[1], 10)
+    return Number.isFinite(n) ? n : null
+}
+
+const PLAYOFF_KEYWORDS = /semi[-\s]?final|quarter[-\s]?final|state final|gulf coast|super regional|cup final|grand final|playoff|championship final|clubs final|3rd place|third place/i
+
+function isPlayoff(note: string): boolean {
+    return PLAYOFF_KEYWORDS.test(note)
+}
+
+// "4/1/2023" → "2023-04-01"; falsy/unparseable → ''
+function parseScheduleDate(raw: string): string {
+    const m = raw.replace(/\u00a0/g, ' ').trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})/)
+    if (!m) return ''
+    const [, mo, da, yr] = m
+    return `${yr}-${mo.padStart(2, '0')}-${da.padStart(2, '0')}`
+}
+
+// ── Playoff extraction ──────────────────────────────────────────────────────
+//
+// Walk the same parsed schedule and bucket games whose Note marks them as a
+// bracket fixture. Returns matches in source order (we rely on rugbyfl listing
+// rounds chronologically — earlier dates = earlier rounds).
+
+type PlayoffRound = 'quarter' | 'semi' | 'final' | 'third'
+
+interface PlayoffEntry {
+    round: PlayoffRound
+    label: string
+    date: string
+    homeTeam: string
+    awayTeam: string
+    homeScore: number | null
+    awayScore: number | null
+}
+
+function classifyRound(note: string): PlayoffRound | null {
+    const n = note.toLowerCase()
+    if (/quarter[-\s]?final/.test(n)) return 'quarter'
+    if (/semi[-\s]?final/.test(n)) return 'semi'
+    if (/3rd place|third place/.test(n)) return 'third'
+    // Match "final" only after the more specific patterns above so semis don't fall through.
+    if (/\bfinal\b|championship|clubs final|cup final|grand final|state final/.test(n)) return 'final'
+    return null
+}
+
+function extractPlayoffs(matches: ScheduleMatch[]): PlayoffEntry[] {
+    const out: PlayoffEntry[] = []
+    for (const m of matches) {
+        if (isCancelled(m.note)) continue
+        const round = classifyRound(m.note)
+        if (!round) continue
+        out.push({
+            round,
+            label: m.note,
+            date: m.date,
+            homeTeam: m.homeName,
+            awayTeam: m.awayName,
+            homeScore: m.homeScore,
+            awayScore: m.awayScore,
+        })
+    }
+    return out
+}
+
+// Returns true when the note explicitly states the game was cancelled and NOT
+// played (forfeits where the game was actually played should still count).
+function isCancelled(note: string): boolean {
+    if (!note) return false
+    if (/game not played/i.test(note)) return true
+    if (/^cancel(l)?ed/i.test(note) && !/forfeit/i.test(note)) return true
+    return false
+}
+
+// Standard World Rugby league scoring — what rugbyfl uses when they bother to
+// publish it. We recompute fresh from the schedule rather than trusting
+// rugbyfl's TP/BP columns because their older seasons have gaps (lots of zero
+// TPs even for clear wins).
+//
+//   Win   = 4
+//   Draw  = 2
+//   Loss  = 0
+//   +1 try bonus    when a team scores ≥ 4 tries
+//   +1 losing bonus when a team loses by ≤ 7
+function computeStandingsFromSchedule(matches: ScheduleMatch[]): ScrapedRow[] {
+    interface Accum {
+        teamName: string
+        played: number
+        won: number
+        lost: number
+        drawn: number
+        pointsFor: number
+        pointsAgainst: number
+        bonusPoints: number
+        totalPoints: number
+    }
+    const byTeam = new Map<string, Accum>()
+
+    const ensure = (name: string): Accum => {
+        const existing = byTeam.get(name)
+        if (existing) return existing
+        const fresh: Accum = {
+            teamName: name,
+            played: 0,
+            won: 0,
+            lost: 0,
+            drawn: 0,
+            pointsFor: 0,
+            pointsAgainst: 0,
+            bonusPoints: 0,
+            totalPoints: 0,
+        }
+        byTeam.set(name, fresh)
+        return fresh
+    }
+
+    for (const m of matches) {
+        if (isCancelled(m.note)) continue
+        if (isPlayoff(m.note)) continue
+        if (m.homeScore == null && m.awayScore == null) continue
+
+        const home = ensure(m.homeName)
+        const away = ensure(m.awayName)
+        const hs = m.homeScore ?? 0
+        const as = m.awayScore ?? 0
+
+        home.played++
+        away.played++
+        home.pointsFor += hs
+        home.pointsAgainst += as
+        away.pointsFor += as
+        away.pointsAgainst += hs
+
+        const margin = Math.abs(hs - as)
+        const isForfeit = /forfeit/i.test(m.note)
+
+        // Bonus points — World Rugby standard. Skip bonuses on forfeits where
+        // no real match was played (the winning team didn't actually score
+        // 4 tries on the pitch even though the score is 20-0).
+        let homeBonus = 0
+        let awayBonus = 0
+        if (!isForfeit) {
+            if (m.homeTries >= 4) homeBonus++
+            if (m.awayTries >= 4) awayBonus++
+            if (hs < as && margin <= 7) homeBonus++
+            if (as < hs && margin <= 7) awayBonus++
+        }
+
+        // Match points
+        let homeMatch = 0
+        let awayMatch = 0
+        if (hs > as) {
+            home.won++
+            away.lost++
+            homeMatch = 4
+        } else if (hs < as) {
+            away.won++
+            home.lost++
+            awayMatch = 4
+        } else {
+            home.drawn++
+            away.drawn++
+            homeMatch = 2
+            awayMatch = 2
+        }
+
+        home.bonusPoints += homeBonus
+        away.bonusPoints += awayBonus
+        home.totalPoints += homeMatch + homeBonus
+        away.totalPoints += awayMatch + awayBonus
+    }
+
+    return Array.from(byTeam.values()).map((a) => ({
+        teamName: a.teamName,
+        pool: '', // not derivable from the schedule alone — editable in Studio
+        played: a.played,
+        won: a.won,
+        lost: a.lost,
+        drawn: a.drawn,
+        pointsFor: a.pointsFor,
+        pointsAgainst: a.pointsAgainst,
+        pointsDifference: a.pointsFor - a.pointsAgainst,
+        bonusPoints: a.bonusPoints,
+        totalPoints: a.totalPoints,
+    }))
+}
+
+// Sort by Total Points desc, then Points Difference desc — standard rugby tiebreaker.
+// Position is 1-indexed in display order.
+function sortAndRank(rows: ScrapedRow[]): Array<ScrapedRow & { position: number }> {
+    const sorted = [...rows].sort((a, b) => {
+        if (b.totalPoints !== a.totalPoints) return b.totalPoints - a.totalPoints
+        if (b.pointsDifference !== a.pointsDifference) return b.pointsDifference - a.pointsDifference
+        return a.teamName.localeCompare(b.teamName)
+    })
+    return sorted.map((r, i) => ({ ...r, position: i + 1 }))
+}
+
+interface ChampionshipDoc {
+    _id: string
+    active?: boolean
+    championshipId?: string
+    seasonLabel?: string
+    divisionName?: string
+}
+
+export async function GET(request: Request) {
+    const { searchParams } = new URL(request.url)
+    const force = searchParams.get('force') === 'true'
+    const overrideCid = searchParams.get('championshipId')
+    const overrideSeason = searchParams.get('seasonLabel')
+    const overrideDivision = searchParams.get('divisionName')
+
+    // Auth: cron uses Bearer CRON_SECRET. Manual backfill calls must include the same.
+    const authHeader = request.headers.get('authorization')
+    if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+        return Response.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const sanity = createClient({
+        projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+        dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
+        apiVersion: '2024-01-01',
+        token: process.env.SANITY_API_TOKEN!,
+        useCdn: false,
+    })
+
+    // Resolve target championship: explicit override (manual backfill) wins,
+    // otherwise read the singleton.
+    let championshipId: string
+    let seasonLabel: string
+    let divisionName: string | null
+
+    if (overrideCid && overrideSeason) {
+        championshipId = overrideCid
+        seasonLabel = overrideSeason
+        divisionName = overrideDivision ?? null
+    } else {
+        const doc = await sanity.fetch<ChampionshipDoc | null>(
+            `*[_type == "leagueChampionship" && _id == "leagueChampionship"][0]`,
+        )
+        if (!doc) {
+            return Response.json(
+                { error: 'No leagueChampionship singleton found. Create one in Studio.' },
+                { status: 404 },
+            )
+        }
+        if (!force && doc.active === false) {
+            return Response.json({ skipped: true, reason: 'leagueChampionship.active is false' })
+        }
+        if (!doc.championshipId || !doc.seasonLabel) {
+            return Response.json(
+                { error: 'leagueChampionship is missing championshipId or seasonLabel' },
+                { status: 400 },
+            )
+        }
+        championshipId = doc.championshipId
+        seasonLabel = doc.seasonLabel
+        divisionName = doc.divisionName ?? null
+    }
+
+    const url = `https://rugbyfl.com/Season/Championships/Championship_Print.asp?Championship_ID=${championshipId}`
+    console.log(`[scrape-standings] Fetching ${url}`)
+
+    let res: Response
+    try {
+        res = await fetch(url, {
+            headers: { 'User-Agent': 'Mozilla/5.0 (compatible; ClaymoresScraper/1.0)' },
+            next: { revalidate: 0 },
+        })
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        await stampStatus(sanity, `fetch error: ${message}`)
+        return Response.json({ error: 'fetch failed', detail: message }, { status: 502 })
+    }
+
+    if (!res.ok) {
+        const message = `HTTP ${res.status}`
+        await stampStatus(sanity, message)
+        return Response.json({ error: 'fetch failed', detail: message }, { status: 502 })
+    }
+
+    const html = await res.text()
+    // We always parse the schedule (cheap) — used as a fallback for standings
+    // and as the source for playoff bracket extraction either way.
+    const scheduleMatches = parseScheduleMatches(html)
+    let parsedRows = parseStandings(html)
+    let source: 'standings-table' | 'computed-from-schedule' = 'standings-table'
+
+    // Fallback for championships where rugbyfl hasn't published a standings
+    // table (common for older seasons — page shows "Standings are not available
+    // at this time."). We compute from the per-match TP/BP columns in the
+    // schedule on the same page, which gives an equivalent table.
+    if (parsedRows.length === 0 && scheduleMatches.length > 0) {
+        parsedRows = computeStandingsFromSchedule(scheduleMatches)
+        source = 'computed-from-schedule'
+    }
+
+    if (parsedRows.length === 0) {
+        await stampStatus(sanity, 'parsed 0 rows — page structure may have changed')
+        return Response.json({ error: 'parsed 0 rows' }, { status: 502 })
+    }
+
+    const playoffs = extractPlayoffs(scheduleMatches)
+    const rankedRows = sortAndRank(parsedRows)
+    const docId = `leagueStandings-${championshipId}`
+    const now = new Date().toISOString()
+
+    try {
+        await sanity.createOrReplace({
+            _id: docId,
+            _type: 'leagueStandings',
+            championshipId,
+            seasonLabel,
+            divisionName,
+            lastUpdated: now,
+            rows: rankedRows.map((r) => ({
+                _type: 'row',
+                _key: `r-${r.position}-${slugifyKey(r.teamName)}`,
+                ...r,
+            })),
+            playoffs: playoffs.map((p, i) => ({
+                _type: 'playoffMatch',
+                _key: `p-${i}-${slugifyKey(p.homeTeam)}-${slugifyKey(p.awayTeam)}`,
+                ...p,
+            })),
+        })
+        await stampStatus(
+            sanity,
+            source === 'computed-from-schedule' ? 'success (computed from schedule)' : 'success',
+        )
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        await stampStatus(sanity, `sanity write error: ${message}`)
+        return Response.json({ error: 'sanity write failed', detail: message }, { status: 500 })
+    }
+
+    // Revalidate dependent pages so visitors see new data quickly.
+    // Sanity webhook will also hit /api/revalidate on createOrReplace — this just shortens latency.
+    if (process.env.SANITY_REVALIDATE_SECRET) {
+        try {
+            const revalidateUrl = new URL(request.url)
+            revalidateUrl.pathname = '/api/revalidate'
+            revalidateUrl.searchParams.set('secret', process.env.SANITY_REVALIDATE_SECRET)
+            await fetch(revalidateUrl.toString(), {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ _type: 'leagueStandings', seasonLabel }),
+            })
+        } catch {
+            // best-effort — Sanity webhook will retry the canonical revalidation path anyway
+        }
+    }
+
+    return Response.json({
+        success: true,
+        championshipId,
+        seasonLabel,
+        rowCount: rankedRows.length,
+        playoffCount: playoffs.length,
+        source,
+        url,
+    })
+}
+
+function slugifyKey(s: string): string {
+    return s
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '')
+        .slice(0, 48)
+}
+
+async function stampStatus(
+    sanity: ReturnType<typeof createClient>,
+    status: string,
+): Promise<void> {
+    try {
+        await sanity
+            .patch('leagueChampionship')
+            .set({ lastScrapedAt: new Date().toISOString(), lastScrapeStatus: status })
+            .commit({ autoGenerateArrayKeys: true })
+    } catch {
+        // singleton may not exist yet on first run with override mode — ignore
+    }
+}

--- a/components/event-cards.tsx
+++ b/components/event-cards.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import type { SanityMatch, SanityTeam } from '@/sanity/lib/queries'
+import type { PracticeInstance } from '@/lib/practices'
+import { matchSlug } from '@/lib/seo'
+
+// ── Team / match helpers ────────────────────────────────────────────────────
+
+export const normalizeTeamName = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '')
+
+export function findTeam(name: string, teams: SanityTeam[]): SanityTeam | null {
+    const n = normalizeTeamName(name)
+    for (const team of teams) {
+        const candidates = [team.name, ...(team.aliases ?? [])]
+        if (
+            candidates.some(
+                (alias) =>
+                    n.includes(normalizeTeamName(alias)) || normalizeTeamName(alias).includes(n),
+            )
+        ) {
+            return team
+        }
+    }
+    return null
+}
+
+export function findTeamLogo(name: string, teams: SanityTeam[]): string | null {
+    return findTeam(name, teams)?.logoUrl ?? null
+}
+
+export function findTeamSlug(name: string, teams: SanityTeam[]): string | null {
+    return findTeam(name, teams)?.slug ?? null
+}
+
+export function isClaymores(name: string) {
+    return name.includes('Claymores') || name.includes('IR/Claymores')
+}
+
+export type Result = 'W' | 'L' | 'D' | 'upcoming' | 'cancelled'
+
+export function getResult(m: SanityMatch): Result {
+    if (m.status === 'upcoming') return 'upcoming'
+    if (m.status === 'cancelled') return 'cancelled'
+    if (m.status === 'forfeit_us') return 'L'
+    if (m.status === 'forfeit_them') return 'W'
+    const weHome = isClaymores(m.homeTeam)
+    const ours = weHome ? m.homeScore : m.awayScore
+    const theirs = weHome ? m.awayScore : m.homeScore
+    if (ours > theirs) return 'W'
+    if (ours < theirs) return 'L'
+    return 'D'
+}
+
+export const RESULT_DOT: Record<Result, string> = {
+    W: 'bg-[#77c3ef]',
+    L: 'bg-[#AAAAAA]',
+    D: 'bg-[#fd80b5]',
+    upcoming: 'bg-[#77c3ef]',
+    cancelled: 'bg-[#EAEAEA]',
+}
+
+export const RESULT_PILL: Record<Result, string> = {
+    W: 'bg-[#77c3ef] text-white',
+    L: 'bg-[#EAEAEA] text-[#555555]',
+    D: 'bg-[#fd80b5] text-white',
+    upcoming: 'bg-[#77c3ef]/10 text-[#77c3ef] border border-[#77c3ef]/30',
+    cancelled: 'bg-[#EAEAEA]/50 text-[#555555] border-[#EAEAEA]',
+}
+
+export const RESULT_LABEL: Record<Result, string> = {
+    W: 'W',
+    L: 'L',
+    D: 'D',
+    upcoming: 'Upcoming',
+    cancelled: 'Cancelled',
+}
+
+// ── Shared cards ─────────────────────────────────────────────────────────────
+
+/**
+ * AddressLink — single hyperlink that opens Google Maps by default, switching
+ * to Apple Maps after hydration when the visitor is on iOS or macOS so they
+ * land in their native map app.
+ */
+export function AddressLink({ address }: { address: string }) {
+    const q = encodeURIComponent(address)
+    const googleUrl = `https://www.google.com/maps/search/?api=1&query=${q}`
+    const appleUrl = `https://maps.apple.com/?address=${q}`
+    const [href, setHref] = useState(googleUrl)
+    useEffect(() => {
+        if (
+            typeof navigator !== 'undefined' &&
+            /iPhone|iPad|iPod|Macintosh/i.test(navigator.userAgent)
+        ) {
+            setHref(appleUrl)
+        }
+    }, [appleUrl])
+    return (
+        <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-[#77c3ef] hover:underline"
+        >
+            {address}
+        </a>
+    )
+}
+
+export function MatchCard({ m, teams }: { m: SanityMatch; teams: SanityTeam[] }) {
+    const result = getResult(m)
+    const weHome = isClaymores(m.homeTeam)
+    const opponent = weHome ? m.awayTeam : m.homeTeam
+    const isPlayed = m.status !== 'upcoming' && m.status !== 'cancelled'
+    const ours = weHome ? m.homeScore : m.awayScore
+    const theirs = weHome ? m.awayScore : m.homeScore
+    const homeLogo = findTeamLogo(m.homeTeam, teams)
+    const awayLogo = findTeamLogo(m.awayTeam, teams)
+
+    return (
+        <Link
+            href={`/fixtures/${matchSlug(m)}`}
+            className="flex items-center gap-3 py-2 px-3 rounded-lg border border-[#EAEAEA] bg-white hover:bg-[#F9F9F9] hover:border-[#77c3ef]/40 transition-colors cursor-pointer"
+            aria-label={`View match details: ${m.homeTeam} vs ${m.awayTeam}`}
+        >
+            <div className="flex flex-col items-center gap-1 w-12 shrink-0">
+                {homeLogo ? (
+                    <img src={homeLogo} alt={m.homeTeam} className="w-8 h-8 object-contain" />
+                ) : (
+                    <div className="w-8 h-8 rounded-full bg-[#EAEAEA]" />
+                )}
+                <p className="text-[9px] text-[#555555] text-center leading-tight truncate w-full">
+                    {m.homeTeam}
+                </p>
+            </div>
+
+            <div className="flex-1 flex flex-col items-center gap-1 min-w-0">
+                {isPlayed ? (
+                    <p className="font-mono text-base font-bold text-[#111111]">
+                        {ours} – {theirs}
+                    </p>
+                ) : (
+                    <p className="text-xs font-semibold text-[#77c3ef] uppercase tracking-widest">
+                        vs {opponent}
+                    </p>
+                )}
+                <span className={`text-[10px] font-bold px-2 py-0.5 rounded ${RESULT_PILL[result]}`}>
+                    {RESULT_LABEL[result]}
+                </span>
+            </div>
+
+            <div className="flex flex-col items-center gap-1 w-12 shrink-0">
+                {awayLogo ? (
+                    <img src={awayLogo} alt={m.awayTeam} className="w-8 h-8 object-contain" />
+                ) : (
+                    <div className="w-8 h-8 rounded-full bg-[#EAEAEA]" />
+                )}
+                <p className="text-[9px] text-[#555555] text-center leading-tight truncate w-full">
+                    {m.awayTeam}
+                </p>
+            </div>
+        </Link>
+    )
+}
+
+export function PracticeCard({ instance }: { instance: PracticeInstance }) {
+    const { practice } = instance
+    return (
+        <div className="flex items-start gap-3 py-2 px-3 rounded-lg border border-[#EAEAEA] bg-white">
+            {practice.iconUrl ? (
+                <img
+                    src={practice.iconUrl}
+                    alt={practice.iconAlt ?? practice.title}
+                    className="w-10 h-10 object-contain shrink-0"
+                />
+            ) : (
+                <div className="w-10 h-10 rounded-full bg-[#EAEAEA] shrink-0" />
+            )}
+            <div className="flex-1 min-w-0">
+                <p className="text-[10px] font-bold uppercase tracking-widest text-[#fd80b5]">Practice</p>
+                <p className="text-sm font-semibold text-[#111111] leading-tight">{practice.title}</p>
+                {practice.time && <p className="text-xs text-[#555555] mt-1">{practice.time}</p>}
+                {practice.address && <AddressLink address={practice.address} />}
+                {practice.description && (
+                    <p className="text-xs text-[#555555] mt-1 whitespace-pre-line">
+                        {practice.description}
+                    </p>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/components/league-table.tsx
+++ b/components/league-table.tsx
@@ -1,0 +1,302 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { cache } from 'react'
+import { client } from '@/sanity/lib/client'
+import {
+    currentLeagueStandingsQuery,
+    leagueStandingsBySeasonQuery,
+    teamsQuery,
+    type SanityLeagueStandings,
+    type SanityStandingRow,
+    type SanityTeam,
+} from '@/sanity/lib/queries'
+import { resolveTeam, type ResolvedTeam } from '@/lib/teams'
+
+export const getCurrentStandings = cache(async (): Promise<SanityLeagueStandings | null> => {
+    return client.fetch(currentLeagueStandingsQuery)
+})
+
+export const getStandingsForSeason = cache(
+    async (seasonLabel: string): Promise<SanityLeagueStandings | null> => {
+        return client.fetch(leagueStandingsBySeasonQuery, { seasonLabel })
+    },
+)
+
+const getAllTeams = cache(async (): Promise<SanityTeam[]> => {
+    return client.fetch(teamsQuery)
+})
+
+interface LeagueTableProps {
+    /** When omitted, loads the currently-active championship's standings. */
+    seasonLabel?: string
+    /**
+     * 'full' (default) — Pos · Team · Pool · P · W · L · D · PD · BP · Pts. Matches the rugbyfl.com reference image.
+     * 'compact' — Pos · Team · W · L · Pts. Fits in a ~24rem-wide rail on the homepage.
+     */
+    variant?: 'full' | 'compact'
+    /** Optional class applied to the outer card. */
+    className?: string
+}
+
+const POOL_STYLES: Record<string, string> = {
+    north: 'bg-[#77c3ef]/15 text-[#0a5a8c] border-[#77c3ef]/40',
+    south: 'bg-[#fd80b5]/15 text-[#9a2168] border-[#fd80b5]/40',
+    combo: 'bg-[#EAEAEA] text-[#444] border-[#D4D4D4]',
+    unique: 'bg-[#EAEAEA] text-[#444] border-[#D4D4D4]',
+}
+
+function poolBadgeClass(pool: string | null): string {
+    if (!pool) return POOL_STYLES.combo
+    const key = pool.toLowerCase().trim()
+    return POOL_STYLES[key] ?? POOL_STYLES.combo
+}
+
+export default async function LeagueTable({
+    seasonLabel,
+    variant = 'full',
+    className = '',
+}: LeagueTableProps) {
+    const [doc, teams] = await Promise.all([
+        seasonLabel ? getStandingsForSeason(seasonLabel) : getCurrentStandings(),
+        getAllTeams(),
+    ])
+
+    if (!doc || !doc.rows || doc.rows.length === 0) {
+        return (
+            <aside
+                className={`border border-[#EAEAEA] rounded-xl bg-white p-6 text-center ${className}`}
+            >
+                <p className="text-sm text-[#555]">Standings TBD.</p>
+            </aside>
+        )
+    }
+
+    const resolved = doc.rows.map((row) => ({
+        row,
+        team: resolveTeam(row.teamName, teams),
+    }))
+
+    if (variant === 'compact') {
+        return <CompactTable doc={doc} resolved={resolved} className={className} />
+    }
+    return <FullTable doc={doc} resolved={resolved} className={className} />
+}
+
+interface InnerProps {
+    doc: SanityLeagueStandings
+    resolved: Array<{ row: SanityStandingRow; team: ResolvedTeam }>
+    className: string
+}
+
+function FullTable({ doc, resolved, className }: InnerProps) {
+    return (
+        <section
+            className={`border border-[#EAEAEA] rounded-xl bg-white overflow-hidden shadow-sm ${className}`}
+            aria-labelledby="league-table-heading"
+        >
+            <header className="bg-[#fd80b5] text-white px-4 py-3">
+                <h2 id="league-table-heading" className="font-claymore text-lg leading-tight">
+                    {doc.divisionName ?? 'League Standings'} {doc.seasonLabel}
+                </h2>
+            </header>
+
+            <div className="px-4 py-3 text-[10px] uppercase tracking-widest text-[#555] border-b border-[#EAEAEA] hidden md:block">
+                <span className="font-bold">P</span>={'\u00A0'}Played{' '}|{' '}
+                <span className="font-bold">W</span>={'\u00A0'}Wins{' '}|{' '}
+                <span className="font-bold">L</span>={'\u00A0'}Losses{' '}|{' '}
+                <span className="font-bold">D</span>={'\u00A0'}Draws{' '}|{' '}
+                <span className="font-bold">PD</span>={'\u00A0'}Points Difference{' '}|{' '}
+                <span className="font-bold">BP</span>={'\u00A0'}Bonus Points{' '}|{' '}
+                <span className="font-bold">Pts</span>={'\u00A0'}Total Points
+            </div>
+
+            <div className="overflow-x-auto">
+                <table className="w-full text-sm border-collapse">
+                    <thead>
+                        <tr className="text-left text-[11px] uppercase tracking-widest text-[#555] border-b border-[#EAEAEA] bg-[#FAFAFA]">
+                            <th scope="col" className="px-3 py-2.5 w-10">Pos</th>
+                            <th scope="col" className="px-3 py-2.5">Team</th>
+                            <th scope="col" className="px-3 py-2.5 hidden md:table-cell">Pool</th>
+                            <th scope="col" className="px-2 py-2.5 text-center w-10">P</th>
+                            <th scope="col" className="px-2 py-2.5 text-center w-10">W</th>
+                            <th scope="col" className="px-2 py-2.5 text-center w-10">L</th>
+                            <th scope="col" className="px-2 py-2.5 text-center w-10">D</th>
+                            <th scope="col" className="px-2 py-2.5 text-center w-14 hidden sm:table-cell">PD</th>
+                            <th scope="col" className="px-2 py-2.5 text-center w-12 hidden sm:table-cell">BP</th>
+                            <th scope="col" className="px-2 py-2.5 text-center w-12">Pts</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {resolved.map(({ row, team }) => (
+                            <Row key={`${row.position}-${row.teamName}`} row={row} team={team} />
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+
+        </section>
+    )
+}
+
+function Row({ row, team }: { row: SanityStandingRow; team: ResolvedTeam }) {
+    const isUs = team.isClaymores
+    const baseBg = isUs ? 'bg-[#fd80b5]/10' : 'bg-white'
+    const fontWeight = isUs ? 'font-bold' : ''
+    return (
+        <tr className={`${baseBg} ${fontWeight} border-b border-[#EAEAEA] last:border-b-0 hover:bg-[#FAFAFA] transition-colors`}>
+            <td className="px-3 py-2.5 text-[#555]">{row.position}</td>
+            <td className="px-3 py-2.5">
+                <div className="flex items-center gap-2.5 min-w-0">
+                    {team.logoUrl ? (
+                        <Image
+                            src={team.logoUrl}
+                            alt={team.logoAlt ?? `${team.name} logo`}
+                            width={24}
+                            height={24}
+                            className="w-6 h-6 shrink-0 object-contain"
+                            unoptimized
+                        />
+                    ) : (
+                        <div className="w-6 h-6 shrink-0 rounded-full bg-[#EAEAEA]" aria-hidden="true" />
+                    )}
+                    {(() => {
+                        const href = team.isClaymores ? '/team' : team.slug ? `/opponents/${team.slug}` : null
+                        return href ? (
+                            <Link href={href} className="truncate text-[#111] hover:underline">
+                                {team.name}
+                            </Link>
+                        ) : (
+                            <span className="truncate text-[#111]">{team.name}</span>
+                        )
+                    })()}
+                </div>
+            </td>
+            <td className="px-3 py-2.5 hidden md:table-cell">
+                <PoolBadge pool={row.pool} />
+            </td>
+            <td className="px-2 py-2.5 text-center tabular-nums">{row.played}</td>
+            <td className="px-2 py-2.5 text-center tabular-nums">{row.won}</td>
+            <td className="px-2 py-2.5 text-center tabular-nums">{row.lost}</td>
+            <td className="px-2 py-2.5 text-center tabular-nums">{row.drawn}</td>
+            <td className="px-2 py-2.5 text-center tabular-nums hidden sm:table-cell">
+                {formatSigned(row.pointsDifference)}
+            </td>
+            <td className="px-2 py-2.5 text-center tabular-nums hidden sm:table-cell">{row.bonusPoints}</td>
+            <td className="px-2 py-2.5 text-center tabular-nums font-semibold">{row.totalPoints}</td>
+        </tr>
+    )
+}
+
+function CompactTable({ doc, resolved, className }: InnerProps) {
+    return (
+        <aside
+            className={`border border-[#EAEAEA] rounded-xl bg-white overflow-hidden shadow-sm aspect-square flex flex-col ${className}`}
+            aria-labelledby="league-table-heading-compact"
+        >
+            <header className="bg-[#fd80b5] text-white px-4 py-3 shrink-0 flex items-center justify-between">
+                <h2 id="league-table-heading-compact" className="font-claymore text-base leading-tight truncate">
+                    {doc.divisionName ?? 'Standings'}
+                </h2>
+                <span className="text-[10px] uppercase tracking-widest opacity-80">{doc.seasonLabel}</span>
+            </header>
+
+            <div className="flex-1 min-h-0 overflow-y-auto">
+                <table className="w-full text-xs border-collapse">
+                    <thead className="sticky top-0 bg-[#FAFAFA]">
+                        <tr className="text-left text-[10px] uppercase tracking-widest text-[#555] border-b border-[#EAEAEA]">
+                            <th scope="col" className="px-2 py-2 w-7">#</th>
+                            <th scope="col" className="px-2 py-2">Team</th>
+                            <th scope="col" className="px-1.5 py-2 text-center w-7">W</th>
+                            <th scope="col" className="px-1.5 py-2 text-center w-7">L</th>
+                            <th scope="col" className="px-1.5 py-2 text-center w-9 font-bold">Pts</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {resolved.map(({ row, team }) => {
+                            const isUs = team.isClaymores
+                            const href = isUs ? '/team' : team.slug ? `/opponents/${team.slug}` : null
+                            const teamInner = (
+                                <div className="flex items-center gap-1.5 min-w-0">
+                                    {team.logoUrl ? (
+                                        <Image
+                                            src={team.logoUrl}
+                                            alt={team.logoAlt ?? `${team.name} logo`}
+                                            width={18}
+                                            height={18}
+                                            className="w-4.5 h-4.5 shrink-0 object-contain"
+                                            unoptimized
+                                        />
+                                    ) : (
+                                        <div className="w-4 h-4 shrink-0 rounded-full bg-[#EAEAEA]" aria-hidden="true" />
+                                    )}
+                                    <span className="truncate text-[#111]">{team.name}</span>
+                                </div>
+                            )
+                            return (
+                                <tr
+                                    key={`${row.position}-${row.teamName}`}
+                                    className={`border-b border-[#EAEAEA] last:border-b-0 ${
+                                        isUs ? 'bg-[#fd80b5]/10 font-bold' : 'bg-white'
+                                    } ${href ? 'hover:bg-[#F9F9F9] cursor-pointer transition-colors' : ''}`}
+                                >
+                                    <td className="px-2 py-1.5 text-[#555] tabular-nums">{row.position}</td>
+                                    <td className="px-2 py-1.5">
+                                        {href ? (
+                                            <Link
+                                                href={href}
+                                                className="block hover:opacity-80 transition-opacity"
+                                                aria-label={`${team.name} ${isUs ? 'team page' : 'opponent page'}`}
+                                            >
+                                                {teamInner}
+                                            </Link>
+                                        ) : (
+                                            teamInner
+                                        )}
+                                    </td>
+                                    <td className="px-1.5 py-1.5 text-center tabular-nums">{row.won}</td>
+                                    <td className="px-1.5 py-1.5 text-center tabular-nums">{row.lost}</td>
+                                    <td className="px-1.5 py-1.5 text-center tabular-nums">{row.totalPoints}</td>
+                                </tr>
+                            )
+                        })}
+                    </tbody>
+                </table>
+            </div>
+
+            <footer className="px-3 py-2 border-t border-[#EAEAEA] text-right shrink-0">
+                <Link
+                    href={`/results/${seasonYearForUrl(doc.seasonLabel)}`}
+                    className="text-[10px] font-semibold uppercase tracking-widest text-[#fd80b5] hover:underline"
+                >
+                    Full standings →
+                </Link>
+            </footer>
+        </aside>
+    )
+}
+
+function PoolBadge({ pool }: { pool: string | null }) {
+    if (!pool) return null
+    return (
+        <span
+            className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-widest border ${poolBadgeClass(pool)}`}
+        >
+            {pool}
+        </span>
+    )
+}
+
+function formatSigned(n: number): string {
+    if (n > 0) return `+${n}`
+    return String(n)
+}
+
+// Convert "2025-2026" → "2026" so links match the /results/[season] route which
+// uses the closing year as its URL segment.
+function seasonYearForUrl(seasonLabel: string): string {
+    const range = seasonLabel.match(/(\d{4})\s*-\s*(\d{4})/)
+    if (range) return range[2]
+    const single = seasonLabel.match(/\d{4}/)
+    return single ? single[0] : seasonLabel
+}
+

--- a/components/match-calendar.tsx
+++ b/components/match-calendar.tsx
@@ -1,179 +1,22 @@
 'use client'
 
-import { useEffect, useState, useMemo } from 'react'
-import Link from 'next/link'
+import { useState, useMemo } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import type { SanityMatch, SanityTeam, SanityPractice } from '@/sanity/lib/queries'
 import { expandPractices, type PracticeInstance } from '@/lib/practices'
-
-const normalizeTeamName = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '')
-
-function findTeam(name: string, teams: SanityTeam[]): SanityTeam | null {
-    const n = normalizeTeamName(name)
-    for (const team of teams) {
-        const candidates = [team.name, ...(team.aliases ?? [])]
-        if (candidates.some(alias => n.includes(normalizeTeamName(alias)) || normalizeTeamName(alias).includes(n))) {
-            return team
-        }
-    }
-    return null
-}
-
-function findTeamLogo(name: string, teams: SanityTeam[]): string | null {
-    return findTeam(name, teams)?.logoUrl ?? null
-}
-
-function findTeamSlug(name: string, teams: SanityTeam[]): string | null {
-    return findTeam(name, teams)?.slug ?? null
-}
-
-function isClaymores(name: string) {
-    return name.includes('Claymores') || name.includes('IR/Claymores')
-}
-
-type Result = 'W' | 'L' | 'D' | 'upcoming' | 'cancelled'
-
-function getResult(m: SanityMatch): Result {
-    if (m.status === 'upcoming') return 'upcoming'
-    if (m.status === 'cancelled') return 'cancelled'
-    if (m.status === 'forfeit_us') return 'L'
-    if (m.status === 'forfeit_them') return 'W'
-    const weHome = isClaymores(m.homeTeam)
-    const ours = weHome ? m.homeScore : m.awayScore
-    const theirs = weHome ? m.awayScore : m.homeScore
-    if (ours > theirs) return 'W'
-    if (ours < theirs) return 'L'
-    return 'D'
-}
-
-const DOT: Record<Result, string> = {
-    W: 'bg-[#77c3ef]',
-    L: 'bg-[#AAAAAA]',
-    D: 'bg-[#fd80b5]',
-    upcoming: 'bg-[#77c3ef]',
-    cancelled: 'bg-[#EAEAEA]',
-}
-
-const PILL: Record<Result, string> = {
-    W: 'bg-[#77c3ef] text-white',
-    L: 'bg-[#EAEAEA] text-[#555555]',
-    D: 'bg-[#fd80b5] text-white',
-    upcoming: 'bg-[#77c3ef]/10 text-[#77c3ef] border border-[#77c3ef]/30',
-    cancelled: 'bg-[#EAEAEA] text-[#999]',
-}
-
-const RESULT_LABEL: Record<Result, string> = {
-    W: 'W', L: 'L', D: 'D', upcoming: 'Upcoming', cancelled: 'Cancelled',
-}
+import {
+    MatchCard,
+    PracticeCard,
+    findTeamLogo,
+    isClaymores,
+    getResult,
+    RESULT_DOT as DOT,
+} from '@/components/event-cards'
 
 const MONTHS = ['January','February','March','April','May','June',
                  'July','August','September','October','November','December']
 const DAYS = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat']
-
-function MatchCard({ m, teams }: { m: SanityMatch, teams: SanityTeam[] }) {
-    const result = getResult(m)
-    const weHome = isClaymores(m.homeTeam)
-    const opponent = weHome ? m.awayTeam : m.homeTeam
-    const isPlayed = m.status !== 'upcoming' && m.status !== 'cancelled'
-    const ours = weHome ? m.homeScore : m.awayScore
-    const theirs = weHome ? m.awayScore : m.homeScore
-    const homeLogo = findTeamLogo(m.homeTeam, teams)
-    const awayLogo = findTeamLogo(m.awayTeam, teams)
-
-    const homeSlug = m.homeTeamSlug ?? findTeamSlug(m.homeTeam, teams)
-    const awaySlug = m.awayTeamSlug ?? findTeamSlug(m.awayTeam, teams)
-    const homeHref = isClaymores(m.homeTeam) ? '/team' : homeSlug ? `/opponents/${homeSlug}` : null
-    const awayHref = isClaymores(m.awayTeam) ? '/team' : awaySlug ? `/opponents/${awaySlug}` : null
-
-    const HomeTeam = () => (
-        <div className="flex flex-col items-center gap-1 w-12 shrink-0">
-            {homeLogo
-                ? <img src={homeLogo} alt={m.homeTeam} className="w-8 h-8 object-contain" />
-                : <div className="w-8 h-8 rounded-full bg-[#EAEAEA]" />}
-            <p className="text-[9px] text-[#555555] text-center leading-tight truncate w-full">{m.homeTeam}</p>
-        </div>
-    )
-    const AwayTeam = () => (
-        <div className="flex flex-col items-center gap-1 w-12 shrink-0">
-            {awayLogo
-                ? <img src={awayLogo} alt={m.awayTeam} className="w-8 h-8 object-contain" />
-                : <div className="w-8 h-8 rounded-full bg-[#EAEAEA]" />}
-            <p className="text-[9px] text-[#555555] text-center leading-tight truncate w-full">{m.awayTeam}</p>
-        </div>
-    )
-
-    return (
-        <div className="flex items-center gap-3 py-2 px-3 rounded-lg border border-[#EAEAEA] bg-white">
-            {/* Home */}
-            {homeHref
-                ? <Link href={homeHref} className="hover:opacity-75 transition-opacity cursor-pointer"><HomeTeam /></Link>
-                : <HomeTeam />}
-
-            {/* Score / result */}
-            <div className="flex-1 flex flex-col items-center gap-1 min-w-0">
-                {isPlayed ? (
-                    <p className="font-mono text-base font-bold text-[#111111]">{ours} – {theirs}</p>
-                ) : (
-                    <p className="text-xs font-semibold text-[#77c3ef] uppercase tracking-widest">vs {opponent}</p>
-                )}
-                <span className={`text-[10px] font-bold px-2 py-0.5 rounded ${PILL[result]}`}>
-                    {RESULT_LABEL[result]}
-                </span>
-            </div>
-
-            {/* Away */}
-            {awayHref
-                ? <Link href={awayHref} className="hover:opacity-75 transition-opacity cursor-pointer"><AwayTeam /></Link>
-                : <AwayTeam />}
-        </div>
-    )
-}
-
-function AddressLink({ address }: { address: string }) {
-    const q = encodeURIComponent(address)
-    const googleUrl = `https://www.google.com/maps/search/?api=1&query=${q}`
-    const appleUrl = `https://maps.apple.com/?address=${q}`
-    // Default to Google Maps for SSR + non-Apple platforms; swap to Apple Maps
-    // after hydration when the visitor is on iOS / macOS so they land in their
-    // native map app instead of a Google redirect.
-    const [href, setHref] = useState(googleUrl)
-    useEffect(() => {
-        if (typeof navigator !== 'undefined' && /iPhone|iPad|iPod|Macintosh/i.test(navigator.userAgent)) {
-            setHref(appleUrl)
-        }
-    }, [appleUrl])
-    return (
-        <a
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-xs text-[#77c3ef] hover:underline"
-        >
-            {address}
-        </a>
-    )
-}
-
-function PracticeCard({ instance }: { instance: PracticeInstance }) {
-    const { practice } = instance
-    return (
-        <div className="flex items-start gap-3 py-2 px-3 rounded-lg border border-[#EAEAEA] bg-white">
-            {practice.iconUrl
-                ? <img src={practice.iconUrl} alt={practice.iconAlt ?? practice.title} className="w-10 h-10 object-contain shrink-0" />
-                : <div className="w-10 h-10 rounded-full bg-[#EAEAEA] shrink-0" />}
-            <div className="flex-1 min-w-0">
-                <p className="text-[10px] font-bold uppercase tracking-widest text-[#fd80b5]">Practice</p>
-                <p className="text-sm font-semibold text-[#111111] leading-tight">{practice.title}</p>
-                {practice.time && <p className="text-xs text-[#555555] mt-1">{practice.time}</p>}
-                {practice.address && <AddressLink address={practice.address} />}
-                {practice.description && (
-                    <p className="text-xs text-[#555555] mt-1 whitespace-pre-line">{practice.description}</p>
-                )}
-            </div>
-        </div>
-    )
-}
 
 // ── Mobile list view ─────────────────────────────────────────────────────────
 

--- a/components/playoff-bracket.tsx
+++ b/components/playoff-bracket.tsx
@@ -1,0 +1,216 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { cache } from 'react'
+import { client } from '@/sanity/lib/client'
+import {
+    leagueStandingsBySeasonQuery,
+    teamsQuery,
+    type PlayoffRound,
+    type SanityLeagueStandings,
+    type SanityPlayoffMatch,
+    type SanityTeam,
+} from '@/sanity/lib/queries'
+import { resolveTeam, type ResolvedTeam } from '@/lib/teams'
+
+const getAllTeams = cache(async (): Promise<SanityTeam[]> => {
+    return client.fetch(teamsQuery)
+})
+
+const getStandingsForSeason = cache(
+    async (seasonLabel: string): Promise<SanityLeagueStandings | null> => {
+        return client.fetch(leagueStandingsBySeasonQuery, { seasonLabel })
+    },
+)
+
+interface PlayoffBracketProps {
+    /** When provided, fetches playoffs by seasonLabel (e.g. "2022-2023"). */
+    seasonLabel?: string
+    /** Or pass the playoffs array directly (lets parents share a doc fetch). */
+    playoffs?: SanityPlayoffMatch[] | null
+    /** Heading suffix. Falls back to seasonLabel when provided. */
+    headingLabel?: string
+    className?: string
+}
+
+const ROUND_ORDER: PlayoffRound[] = ['quarter', 'semi', 'third', 'final']
+
+const ROUND_TITLE: Record<PlayoffRound, string> = {
+    quarter: 'Quarter-Finals',
+    semi: 'Semi-Finals',
+    third: '3rd Place',
+    final: 'Final',
+}
+
+export default async function PlayoffBracket({
+    playoffs,
+    seasonLabel,
+    headingLabel,
+    className = '',
+}: PlayoffBracketProps) {
+    let resolvedPlayoffs: SanityPlayoffMatch[] | null | undefined = playoffs
+    let label = headingLabel ?? seasonLabel ?? ''
+
+    if (!resolvedPlayoffs && seasonLabel) {
+        const doc = await getStandingsForSeason(seasonLabel)
+        resolvedPlayoffs = doc?.playoffs ?? null
+        label = headingLabel ?? doc?.seasonLabel ?? seasonLabel
+    }
+
+    if (!resolvedPlayoffs || resolvedPlayoffs.length === 0) return null
+
+    const teams = await getAllTeams()
+
+    // Bucket by round, preserving source order (which is chronological).
+    const byRound = new Map<PlayoffRound, SanityPlayoffMatch[]>()
+    for (const m of resolvedPlayoffs) {
+        const list = byRound.get(m.round) ?? []
+        list.push(m)
+        byRound.set(m.round, list)
+    }
+
+    const columns = ROUND_ORDER.filter((r) => byRound.has(r)).map((round) => ({
+        round,
+        title: ROUND_TITLE[round],
+        matches: byRound.get(round)!,
+    }))
+
+    if (columns.length === 0) return null
+
+    return (
+        <section
+            className={`border border-[#EAEAEA] rounded-xl bg-white overflow-hidden shadow-sm ${className}`}
+            aria-labelledby="playoff-bracket-heading"
+        >
+            <header className="bg-[#fd80b5] text-white px-4 py-3 flex items-baseline justify-between gap-3">
+                <h2 id="playoff-bracket-heading" className="font-claymore text-lg leading-tight">
+                    Playoffs {label}
+                </h2>
+                <span className="text-[10px] uppercase tracking-widest text-white/80">
+                    Bracket
+                </span>
+            </header>
+
+            <div className="overflow-x-auto">
+                <div
+                    className="flex gap-6 md:gap-10 p-4 md:p-6 min-w-max"
+                    role="list"
+                    aria-label="Playoff rounds"
+                >
+                    {columns.map((col) => (
+                        <RoundColumn
+                            key={col.round}
+                            title={col.title}
+                            matches={col.matches}
+                            teams={teams}
+                        />
+                    ))}
+                </div>
+            </div>
+        </section>
+    )
+}
+
+function RoundColumn({
+    title,
+    matches,
+    teams,
+}: {
+    title: string
+    matches: SanityPlayoffMatch[]
+    teams: SanityTeam[]
+}) {
+    return (
+        <div
+            role="listitem"
+            className="flex flex-col justify-center gap-4 md:gap-6 min-w-[16rem] md:min-w-[18rem]"
+        >
+            <h3 className="text-[11px] font-semibold uppercase tracking-widest text-[#555] text-center">
+                {title}
+            </h3>
+            <div className="flex flex-col gap-4 md:gap-6 flex-1 justify-around">
+                {matches.map((m, i) => (
+                    <BracketMatch key={`${title}-${i}-${m.homeTeam}-${m.awayTeam}`} match={m} teams={teams} />
+                ))}
+            </div>
+        </div>
+    )
+}
+
+function BracketMatch({ match, teams }: { match: SanityPlayoffMatch; teams: SanityTeam[] }) {
+    const home = resolveTeam(match.homeTeam, teams)
+    const away = resolveTeam(match.awayTeam, teams)
+    const hs = match.homeScore
+    const as = match.awayScore
+    const hasScores = typeof hs === 'number' && typeof as === 'number'
+    const homeWon = hasScores && hs! > as!
+    const awayWon = hasScores && as! > hs!
+
+    return (
+        <article className="rounded-lg border border-[#EAEAEA] bg-white shadow-sm overflow-hidden">
+            {match.label || match.date ? (
+                <div className="px-3 py-1.5 bg-[#FAFAFA] border-b border-[#EAEAEA] flex items-center justify-between gap-2 text-[10px] uppercase tracking-widest text-[#777]">
+                    <span className="truncate">{match.label ?? ''}</span>
+                    {match.date && <time dateTime={match.date}>{formatShortDate(match.date)}</time>}
+                </div>
+            ) : null}
+            <TeamRow team={home} score={hs} won={homeWon} />
+            <div className="h-px bg-[#EAEAEA]" />
+            <TeamRow team={away} score={as} won={awayWon} />
+        </article>
+    )
+}
+
+function TeamRow({
+    team,
+    score,
+    won,
+}: {
+    team: ResolvedTeam
+    score: number | null
+    won: boolean
+}) {
+    const isUs = team.isClaymores
+    const href = isUs ? '/team' : team.slug ? `/opponents/${team.slug}` : null
+    const bg = won ? 'bg-[#fd80b5]/10' : 'bg-white'
+    const fontWeight = won ? 'font-bold text-[#111]' : 'text-[#333]'
+
+    const body = (
+        <div className={`flex items-center gap-2.5 px-3 py-2.5 ${bg} ${fontWeight}`}>
+            {team.logoUrl ? (
+                <Image
+                    src={team.logoUrl}
+                    alt={team.logoAlt ?? `${team.name} logo`}
+                    width={24}
+                    height={24}
+                    className="w-6 h-6 shrink-0 object-contain"
+                    unoptimized
+                />
+            ) : (
+                <div className="w-6 h-6 shrink-0 rounded-full bg-[#EAEAEA]" aria-hidden="true" />
+            )}
+            <span className={`flex-1 truncate text-sm ${isUs ? 'text-[#111]' : ''}`}>{team.name}</span>
+            <span className="tabular-nums font-mono text-base shrink-0">
+                {typeof score === 'number' ? score : '—'}
+            </span>
+        </div>
+    )
+
+    if (!href) return body
+    return (
+        <Link href={href} className="block hover:bg-[#FAFAFA] transition-colors">
+            {body}
+        </Link>
+    )
+}
+
+function formatShortDate(iso: string): string {
+    // iso is YYYY-MM-DD — parse in UTC to avoid TZ off-by-one on display.
+    const [y, m, d] = iso.split('-').map((n) => parseInt(n, 10))
+    if (!y || !m || !d) return iso
+    const date = new Date(Date.UTC(y, m - 1, d))
+    return date.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+    })
+}

--- a/components/upcoming-events.tsx
+++ b/components/upcoming-events.tsx
@@ -4,12 +4,15 @@ import { useMemo, useState } from 'react'
 import Link from 'next/link'
 import { CalendarDays, ChevronLeft, ChevronRight, List } from 'lucide-react'
 import { AnimatePresence, motion } from 'framer-motion'
-import type { SanityMatch, SanityPractice } from '@/sanity/lib/queries'
-import { expandPractices } from '@/lib/practices'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import type { SanityMatch, SanityPractice, SanityTeam } from '@/sanity/lib/queries'
+import { expandPractices, type PracticeInstance } from '@/lib/practices'
+import { MatchCard, PracticeCard, isClaymores } from '@/components/event-cards'
 
 interface UpcomingEventsProps {
     matches: SanityMatch[]
     practices: SanityPractice[]
+    teams?: SanityTeam[]
     className?: string
 }
 
@@ -17,17 +20,23 @@ type CalEvent =
     | { kind: 'match'; date: string; key: string; label: string; time?: string | null }
     | { kind: 'practice'; date: string; key: string; label: string; time?: string | null }
 
+interface DayBucket {
+    matches: SanityMatch[]
+    practices: PracticeInstance[]
+}
+
 const MONTHS = [
     'January', 'February', 'March', 'April', 'May', 'June',
     'July', 'August', 'September', 'October', 'November', 'December',
 ]
 const DAY_LETTERS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
 
-function isClaymores(name: string) {
-    return name.includes('Claymores') || name.includes('IR/Claymores')
-}
-
-export default function UpcomingEvents({ matches, practices, className = '' }: UpcomingEventsProps) {
+export default function UpcomingEvents({
+    matches,
+    practices,
+    teams = [],
+    className = '',
+}: UpcomingEventsProps) {
     const today = new Date()
     const [year, setYear] = useState(today.getFullYear())
     const [month, setMonth] = useState(today.getMonth())
@@ -42,12 +51,28 @@ export default function UpcomingEvents({ matches, practices, className = '' }: U
         else setMonth((m) => m + 1)
     }
 
-    const monthEvents = useMemo<CalEvent[]>(() => {
+    // Per-month bundle: raw matches + expanded practice instances, used both for
+    // the agenda list and the grid view's day-cell popovers.
+    const monthData = useMemo(() => {
         const firstIso = `${year}-${String(month + 1).padStart(2, '0')}-01`
         const lastDay = new Date(year, month + 1, 0).getDate()
         const lastIso = `${year}-${String(month + 1).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
-        const inMonth = matches.filter((m) => m.status === 'upcoming' && m.date >= firstIso && m.date <= lastIso)
+        // Include played + upcoming + cancelled — matches the fixtures calendar.
+        // Filtering happens via month range; status is reflected in the popup card.
+        const inMonth = matches.filter((m) => m.date >= firstIso && m.date <= lastIso)
         const instances = expandPractices(practices, firstIso, lastIso)
+
+        const byDate = new Map<string, DayBucket>()
+        const ensure = (date: string): DayBucket => {
+            const existing = byDate.get(date)
+            if (existing) return existing
+            const fresh: DayBucket = { matches: [], practices: [] }
+            byDate.set(date, fresh)
+            return fresh
+        }
+        for (const m of inMonth) ensure(m.date).matches.push(m)
+        for (const p of instances) ensure(p.date).practices.push(p)
+
         const evts: CalEvent[] = [
             ...inMonth.map<CalEvent>((m) => {
                 const opp = isClaymores(m.homeTeam) ? m.awayTeam : m.homeTeam
@@ -60,40 +85,41 @@ export default function UpcomingEvents({ matches, practices, className = '' }: U
                 label: p.practice.title,
                 time: p.practice.time,
             })),
-        ]
-        return evts.sort((a, b) => a.date.localeCompare(b.date))
+        ].sort((a, b) => a.date.localeCompare(b.date))
+
+        return { byDate, monthEvents: evts }
     }, [matches, practices, year, month])
 
     const eventsByDate = useMemo(() => {
         const map = new Map<string, CalEvent[]>()
-        for (const e of monthEvents) {
+        for (const e of monthData.monthEvents) {
             if (!map.has(e.date)) map.set(e.date, [])
             map.get(e.date)!.push(e)
         }
         return map
-    }, [monthEvents])
+    }, [monthData])
 
     return (
         <aside className={`border border-[#EAEAEA] rounded-xl bg-white aspect-square flex flex-col overflow-hidden shadow-sm ${className}`}>
             {/* Header: month nav + view toggle */}
-            <div className="flex items-center justify-between px-4 py-3 border-b border-[#EAEAEA] shrink-0">
+            <div className="flex items-center justify-between px-4 py-3 bg-[#fd80b5] text-white shrink-0">
                 <div className="flex items-center gap-1.5">
                     <button
                         onClick={prev}
                         aria-label="Previous month"
-                        className="p-1.5 rounded-md hover:bg-[#F4F4F4] transition-colors"
+                        className="p-1.5 rounded-md hover:bg-white/15 transition-colors"
                     >
-                        <ChevronLeft className="w-4 h-4 text-[#555]" />
+                        <ChevronLeft className="w-4 h-4 text-white" />
                     </button>
-                    <h2 className="font-claymore text-lg text-[#111] px-1 leading-none">
+                    <h2 className="font-claymore text-lg text-white px-1 leading-none">
                         {MONTHS[month]} {year}
                     </h2>
                     <button
                         onClick={next}
                         aria-label="Next month"
-                        className="p-1.5 rounded-md hover:bg-[#F4F4F4] transition-colors"
+                        className="p-1.5 rounded-md hover:bg-white/15 transition-colors"
                     >
-                        <ChevronRight className="w-4 h-4 text-[#555]" />
+                        <ChevronRight className="w-4 h-4 text-white" />
                     </button>
                 </div>
                 <div className="flex gap-1 relative">
@@ -102,13 +128,13 @@ export default function UpcomingEvents({ matches, practices, className = '' }: U
                         aria-label="Calendar view"
                         aria-pressed={view === 'grid'}
                         className={`relative p-1.5 rounded-md transition-colors ${
-                            view === 'grid' ? 'text-[#111]' : 'text-[#AAA] hover:text-[#555]'
+                            view === 'grid' ? 'text-white' : 'text-white/60 hover:text-white'
                         }`}
                     >
                         {view === 'grid' && (
                             <motion.span
                                 layoutId="view-toggle-pill"
-                                className="absolute inset-0 bg-[#F0F0F0] rounded-md"
+                                className="absolute inset-0 bg-white/25 rounded-md"
                                 transition={{ type: 'spring', stiffness: 500, damping: 35 }}
                             />
                         )}
@@ -119,13 +145,13 @@ export default function UpcomingEvents({ matches, practices, className = '' }: U
                         aria-label="Agenda view"
                         aria-pressed={view === 'agenda'}
                         className={`relative p-1.5 rounded-md transition-colors ${
-                            view === 'agenda' ? 'text-[#111]' : 'text-[#AAA] hover:text-[#555]'
+                            view === 'agenda' ? 'text-white' : 'text-white/60 hover:text-white'
                         }`}
                     >
                         {view === 'agenda' && (
                             <motion.span
                                 layoutId="view-toggle-pill"
-                                className="absolute inset-0 bg-[#F0F0F0] rounded-md"
+                                className="absolute inset-0 bg-white/25 rounded-md"
                                 transition={{ type: 'spring', stiffness: 500, damping: 35 }}
                             />
                         )}
@@ -146,9 +172,16 @@ export default function UpcomingEvents({ matches, practices, className = '' }: U
                         className="absolute inset-0"
                     >
                         {view === 'grid' ? (
-                            <GridView year={year} month={month} eventsByDate={eventsByDate} today={today} />
+                            <GridView
+                                year={year}
+                                month={month}
+                                eventsByDate={eventsByDate}
+                                bucketsByDate={monthData.byDate}
+                                teams={teams}
+                                today={today}
+                            />
                         ) : (
-                            <AgendaView events={monthEvents} />
+                            <AgendaView events={monthData.monthEvents} />
                         )}
                     </motion.div>
                 </AnimatePresence>
@@ -171,11 +204,15 @@ function GridView({
     year,
     month,
     eventsByDate,
+    bucketsByDate,
+    teams,
     today,
 }: {
     year: number
     month: number
     eventsByDate: Map<string, CalEvent[]>
+    bucketsByDate: Map<string, DayBucket>
+    teams: SanityTeam[]
     today: Date
 }) {
     const firstDay = new Date(year, month, 1).getDay()
@@ -202,15 +239,15 @@ function GridView({
                     }
                     const iso = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`
                     const events = eventsByDate.get(iso) ?? []
+                    const bucket = bucketsByDate.get(iso)
+                    const hasEvents = events.length > 0
                     const isToday =
                         today.getFullYear() === year &&
                         today.getMonth() === month &&
                         today.getDate() === day
-                    return (
-                        <div
-                            key={iso}
-                            className="bg-white px-1 py-1 flex flex-col items-center justify-start gap-1 overflow-hidden"
-                        >
+
+                    const cellContent = (
+                        <div className="h-full w-full bg-white px-1 py-1 flex flex-col items-center justify-start gap-1 overflow-hidden">
                             <span
                                 className={`text-xs font-medium leading-none flex items-center justify-center w-6 h-6 rounded-full shrink-0 ${
                                     isToday ? 'bg-[#77c3ef] text-white' : 'text-[#111]'
@@ -218,7 +255,7 @@ function GridView({
                             >
                                 {day}
                             </span>
-                            {events.length > 0 && (
+                            {hasEvents && (
                                 <div className="flex gap-0.5 flex-wrap justify-center">
                                     {events.slice(0, 3).map((e) => (
                                         <span
@@ -232,6 +269,41 @@ function GridView({
                                 </div>
                             )}
                         </div>
+                    )
+
+                    if (!hasEvents || !bucket) return <div key={iso}>{cellContent}</div>
+
+                    return (
+                        <Popover key={iso}>
+                            <PopoverTrigger asChild>
+                                <button
+                                    type="button"
+                                    className="text-left h-full w-full cursor-pointer hover:bg-[#77c3ef]/5 transition-colors"
+                                    aria-label={`Events on ${iso}`}
+                                >
+                                    {cellContent}
+                                </button>
+                            </PopoverTrigger>
+                            <PopoverContent side="top" align="center" className="w-72 p-3">
+                                <p className="text-xs uppercase tracking-widest text-[#555] font-semibold mb-2">
+                                    {new Date(`${iso}T00:00:00Z`).toLocaleDateString('en-US', {
+                                        weekday: 'long',
+                                        month: 'long',
+                                        day: 'numeric',
+                                        year: 'numeric',
+                                        timeZone: 'UTC',
+                                    })}
+                                </p>
+                                <div className="flex flex-col gap-2">
+                                    {bucket.matches.map((m) => (
+                                        <MatchCard key={m._id} m={m} teams={teams} />
+                                    ))}
+                                    {bucket.practices.map((inst) => (
+                                        <PracticeCard key={inst.key} instance={inst} />
+                                    ))}
+                                </div>
+                            </PopoverContent>
+                        </Popover>
                     )
                 })}
             </div>

--- a/lib/features.ts
+++ b/lib/features.ts
@@ -17,9 +17,4 @@ export const features = {
     // Default OFF until the coach docs are seeded in Sanity (see
     // scripts/seed-coaches.ts) and have photos uploaded.
     coaches: flag(process.env.NEXT_PUBLIC_COACHES_ENABLED, false),
-
-    // Homepage Upcoming Events calendar widget (desktop right rail + mobile
-    // section after "From the Field"). Default OFF until the league table is
-    // built so the hero section doesn't ship lopsided.
-    homepageCalendar: flag(process.env.NEXT_PUBLIC_HOMEPAGE_CALENDAR_ENABLED, false),
 } as const

--- a/lib/teams.ts
+++ b/lib/teams.ts
@@ -1,0 +1,107 @@
+import type { SanityTeam } from '@/sanity/lib/queries'
+
+// Normalize a team name so we can compare a scraped string to a Sanity name/alias.
+//
+//  • lowercase
+//  • strip suffixes like "RFC", "FC", "F.C."
+//  • strip parenthetical division markers like "(D3)", "(D2)"
+//  • collapse punctuation/whitespace
+//
+// Examples:
+//   "Central Florida Claymores RFC"   →  "central florida claymores"
+//   "Ft. Lauderdale Knights RFC (D3)" →  "ft lauderdale knights"
+//   "SWFL Hammerheads RFC"            →  "swfl hammerheads"
+export function normalizeTeamName(input: string): string {
+    return input
+        .toLowerCase()
+        .replace(/\([^)]*\)/g, ' ') // strip "(D3)", "(D2)", etc.
+        .replace(/\brfc\b/g, ' ')
+        .replace(/\bfc\b/g, ' ')
+        .replace(/\bf\.c\.\b/g, ' ')
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim()
+}
+
+export interface ResolvedTeam {
+    name: string
+    logoUrl: string | null
+    logoAlt: string | null
+    slug: string | null
+    isClaymores: boolean
+}
+
+// Try to resolve a scraped team name to one of our Sanity team docs.
+//
+// Match order (most specific → least):
+//   1. exact normalized match on team.name
+//   2. exact normalized match on any team.aliases[]
+//   3. one side fully contains the other (Sanity name "Brevard" appears in
+//      "Brevard Old Red Eye RFC", or vice versa)
+//
+// Returns a ResolvedTeam with logo info if matched, or just the original name
+// (logos null) if not. Caller renders text-only when logo is null.
+export function resolveTeam(scrapedName: string, teams: SanityTeam[]): ResolvedTeam {
+    const norm = normalizeTeamName(scrapedName)
+    const isClaymores = /claymore/i.test(scrapedName)
+
+    if (!norm) {
+        return {
+            name: scrapedName,
+            logoUrl: null,
+            logoAlt: null,
+            slug: null,
+            isClaymores,
+        }
+    }
+
+    let bestExact: SanityTeam | null = null
+    let bestAlias: SanityTeam | null = null
+    let bestContains: SanityTeam | null = null
+
+    for (const team of teams) {
+        const teamNorm = normalizeTeamName(team.name)
+        if (teamNorm && teamNorm === norm) {
+            bestExact = team
+            break
+        }
+
+        if (Array.isArray(team.aliases)) {
+            for (const alias of team.aliases) {
+                if (normalizeTeamName(alias) === norm) {
+                    bestAlias = team
+                    break
+                }
+            }
+        }
+        if (bestAlias) continue
+
+        if (
+            teamNorm &&
+            (norm.includes(teamNorm) || teamNorm.includes(norm))
+        ) {
+            // prefer the longer (more specific) candidate when multiple match
+            if (!bestContains || normalizeTeamName(bestContains.name).length < teamNorm.length) {
+                bestContains = team
+            }
+        }
+    }
+
+    const match = bestExact ?? bestAlias ?? bestContains
+    if (!match) {
+        return {
+            name: scrapedName,
+            logoUrl: null,
+            logoAlt: null,
+            slug: null,
+            isClaymores,
+        }
+    }
+
+    return {
+        name: match.name,
+        logoUrl: match.logoUrl,
+        logoAlt: match.logoAlt ?? `${match.name} logo`,
+        slug: match.slug ?? null,
+        isClaymores,
+    }
+}

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -4,7 +4,7 @@ import { visionTool } from '@sanity/vision'
 import { media } from 'sanity-plugin-media'
 import { schema } from '@/sanity/schema'
 
-const SINGLETON_TYPES = new Set(['practiceSchedule'])
+const SINGLETON_TYPES = new Set(['practiceSchedule', 'leagueChampionship'])
 
 const structure: StructureResolver = (S) =>
     S.list()
@@ -18,6 +18,15 @@ const structure: StructureResolver = (S) =>
                         .schemaType('practiceSchedule')
                         .documentId('practiceSchedule')
                         .title('Practice Schedule'),
+                ),
+            S.listItem()
+                .title('League Championship')
+                .id('leagueChampionship')
+                .child(
+                    S.document()
+                        .schemaType('leagueChampionship')
+                        .documentId('leagueChampionship')
+                        .title('League Championship'),
                 ),
             S.divider(),
             ...S.documentTypeListItems().filter(

--- a/sanity/lib/queries.ts
+++ b/sanity/lib/queries.ts
@@ -329,6 +329,88 @@ export const practicesQuery = groq`
   }
 `
 
+export interface SanityStandingRow {
+    position: number
+    teamName: string
+    pool: string | null
+    played: number
+    won: number
+    lost: number
+    drawn: number
+    pointsFor: number
+    pointsAgainst: number
+    pointsDifference: number
+    bonusPoints: number
+    totalPoints: number
+}
+
+export type PlayoffRound = 'quarter' | 'semi' | 'final' | 'third'
+
+export interface SanityPlayoffMatch {
+    round: PlayoffRound
+    label: string | null
+    date: string | null
+    homeTeam: string
+    awayTeam: string
+    homeScore: number | null
+    awayScore: number | null
+}
+
+export interface SanityLeagueStandings {
+    _id: string
+    _updatedAt?: string
+    championshipId: string
+    seasonLabel: string
+    divisionName: string | null
+    lastUpdated: string | null
+    rows: SanityStandingRow[]
+    playoffs: SanityPlayoffMatch[] | null
+}
+
+// Active championship pointer (singleton) → the standings doc currently being scraped.
+// Falls back to the most-recently-updated standings doc if the singleton is missing
+// (useful before a singleton is published, or during backfills).
+export const currentLeagueStandingsQuery = groq`
+  coalesce(
+    *[_type == "leagueChampionship" && _id == "leagueChampionship"][0] {
+      "doc": *[_type == "leagueStandings" && championshipId == ^.championshipId][0] {
+        _id,
+        _updatedAt,
+        championshipId,
+        seasonLabel,
+        divisionName,
+        lastUpdated,
+        rows,
+        playoffs
+      }
+    }.doc,
+    *[_type == "leagueStandings"] | order(lastUpdated desc) [0] {
+      _id,
+      _updatedAt,
+      championshipId,
+      seasonLabel,
+      divisionName,
+      lastUpdated,
+      rows,
+      playoffs
+    }
+  )
+`
+
+// Lookup by season label — used by /results/[season] for historical standings.
+export const leagueStandingsBySeasonQuery = groq`
+  *[_type == "leagueStandings" && seasonLabel == $seasonLabel] | order(_updatedAt desc) [0] {
+    _id,
+    _updatedAt,
+    championshipId,
+    seasonLabel,
+    divisionName,
+    lastUpdated,
+    rows,
+    playoffs
+  }
+`
+
 export interface SanityTeamPhoto {
     _id: string
     url: string

--- a/sanity/schema/index.ts
+++ b/sanity/schema/index.ts
@@ -5,5 +5,19 @@ import { team } from './team'
 import { coach } from './coach'
 import { practice } from './practice'
 import { practiceSchedule } from './practiceSchedule'
+import { leagueChampionship } from './leagueChampionship'
+import { leagueStandings } from './leagueStandings'
 
-export const schema = { types: [player, post, match, team, coach, practice, practiceSchedule] }
+export const schema = {
+    types: [
+        player,
+        post,
+        match,
+        team,
+        coach,
+        practice,
+        practiceSchedule,
+        leagueChampionship,
+        leagueStandings,
+    ],
+}

--- a/sanity/schema/leagueChampionship.ts
+++ b/sanity/schema/leagueChampionship.ts
@@ -1,0 +1,71 @@
+import { defineField, defineType } from 'sanity'
+
+export const leagueChampionship = defineType({
+    name: 'leagueChampionship',
+    title: 'League Championship',
+    type: 'document',
+    description:
+        'Site-wide canonical pointer to the active rugbyfl.com championship to scrape for the league standings table. There is only one of these documents — update the Championship ID at the start of each new season.',
+    fields: [
+        defineField({
+            name: 'active',
+            title: 'Active',
+            type: 'boolean',
+            description:
+                'Off-season kill switch. When OFF the weekly cron does nothing — turn back ON at the start of the season.',
+            initialValue: true,
+        }),
+        defineField({
+            name: 'championshipId',
+            title: 'Championship ID',
+            type: 'string',
+            description:
+                'The Championship_ID query param from rugbyfl.com (e.g. "191" for Men D3 2025-2026). Update this once per season.',
+            validation: (rule) => rule.required(),
+            initialValue: '191',
+        }),
+        defineField({
+            name: 'seasonLabel',
+            title: 'Season Label',
+            type: 'string',
+            description: 'e.g. "2025-2026". Shown on the table and used as the key for /results/[season] lookups.',
+            validation: (rule) => rule.required(),
+            initialValue: '2025-2026',
+        }),
+        defineField({
+            name: 'divisionName',
+            title: 'Division Name',
+            type: 'string',
+            description: 'e.g. "Men Division 3". Shown as the table heading.',
+            initialValue: 'Men Division 3',
+        }),
+        defineField({
+            name: 'lastScrapedAt',
+            title: 'Last Scraped At',
+            type: 'datetime',
+            description: 'Auto-updated by the scraper — do not edit by hand.',
+            readOnly: true,
+        }),
+        defineField({
+            name: 'lastScrapeStatus',
+            title: 'Last Scrape Status',
+            type: 'string',
+            description: 'Auto-updated by the scraper. "success" on a clean run, error message otherwise.',
+            readOnly: true,
+        }),
+    ],
+    preview: {
+        select: {
+            season: 'seasonLabel',
+            division: 'divisionName',
+            cid: 'championshipId',
+            active: 'active',
+        },
+        prepare({ season, division, cid, active }) {
+            return {
+                title: `${division || 'League'} · ${season || ''}`.trim(),
+                subtitle: `Championship_ID=${cid}${active ? '' : ' · INACTIVE'}`,
+            }
+        },
+    },
+})

--- a/sanity/schema/leagueStandings.ts
+++ b/sanity/schema/leagueStandings.ts
@@ -1,0 +1,159 @@
+import { defineField, defineType } from 'sanity'
+
+export const leagueStandings = defineType({
+    name: 'leagueStandings',
+    title: 'League Standings',
+    type: 'document',
+    description:
+        'A scraped snapshot of a rugbyfl.com championship standings table. One document per Championship_ID — persists forever so /results/[season] can render historical standings. Created and updated by the weekly scraper; do not edit by hand.',
+    fields: [
+        defineField({
+            name: 'championshipId',
+            title: 'Championship ID',
+            type: 'string',
+            description: 'The Championship_ID from rugbyfl.com. Acts as the unique key for this snapshot.',
+            validation: (rule) => rule.required(),
+        }),
+        defineField({
+            name: 'seasonLabel',
+            title: 'Season Label',
+            type: 'string',
+            description: 'e.g. "2025-2026". Used as the lookup key for /results/[season].',
+            validation: (rule) => rule.required(),
+        }),
+        defineField({
+            name: 'divisionName',
+            title: 'Division Name',
+            type: 'string',
+            description: 'e.g. "Men Division 3".',
+        }),
+        defineField({
+            name: 'lastUpdated',
+            title: 'Last Updated',
+            type: 'datetime',
+            description: 'When the scraper last refreshed this snapshot.',
+            readOnly: true,
+        }),
+        defineField({
+            name: 'playoffs',
+            title: 'Playoff Matches',
+            description:
+                'Auto-populated by the scraper from notes like "Semi-Final #1", "Final", "Third Place". Used to render the bracket on /results/[season]. Safe to hand-edit if rugbyfl misclassifies a match.',
+            type: 'array',
+            of: [
+                defineField({
+                    name: 'playoffMatch',
+                    type: 'object',
+                    title: 'Playoff Match',
+                    fields: [
+                        defineField({
+                            name: 'round',
+                            title: 'Round',
+                            type: 'string',
+                            options: {
+                                list: [
+                                    { title: 'Quarter-Final', value: 'quarter' },
+                                    { title: 'Semi-Final', value: 'semi' },
+                                    { title: 'Final', value: 'final' },
+                                    { title: 'Third Place', value: 'third' },
+                                ],
+                            },
+                            validation: (rule) => rule.required(),
+                        }),
+                        defineField({
+                            name: 'label',
+                            title: 'Label',
+                            type: 'string',
+                            description: 'Raw note from rugbyfl, e.g. "Semi-Final #1".',
+                        }),
+                        defineField({ name: 'date', title: 'Date', type: 'date' }),
+                        defineField({ name: 'homeTeam', title: 'Home Team', type: 'string' }),
+                        defineField({ name: 'awayTeam', title: 'Away Team', type: 'string' }),
+                        defineField({ name: 'homeScore', title: 'Home Score', type: 'number' }),
+                        defineField({ name: 'awayScore', title: 'Away Score', type: 'number' }),
+                    ],
+                    preview: {
+                        select: {
+                            round: 'round',
+                            label: 'label',
+                            home: 'homeTeam',
+                            away: 'awayTeam',
+                            hs: 'homeScore',
+                            as: 'awayScore',
+                        },
+                        prepare({ round, label, home, away, hs, as }) {
+                            const score =
+                                typeof hs === 'number' && typeof as === 'number' ? ` ${hs}–${as}` : ''
+                            return {
+                                title: `${home || '?'} vs ${away || '?'}${score}`,
+                                subtitle: label || round,
+                            }
+                        },
+                    },
+                }),
+            ],
+        }),
+        defineField({
+            name: 'rows',
+            title: 'Standings Rows',
+            type: 'array',
+            of: [
+                defineField({
+                    name: 'row',
+                    type: 'object',
+                    title: 'Standing Row',
+                    fields: [
+                        defineField({ name: 'position', title: 'Position', type: 'number' }),
+                        defineField({ name: 'teamName', title: 'Team Name', type: 'string' }),
+                        defineField({ name: 'pool', title: 'Pool', type: 'string', description: 'e.g. "North", "South", "Combo", "Unique"' }),
+                        defineField({ name: 'played', title: 'Played', type: 'number' }),
+                        defineField({ name: 'won', title: 'Won', type: 'number' }),
+                        defineField({ name: 'lost', title: 'Lost', type: 'number' }),
+                        defineField({ name: 'drawn', title: 'Drawn', type: 'number' }),
+                        defineField({ name: 'pointsFor', title: 'Points For', type: 'number' }),
+                        defineField({ name: 'pointsAgainst', title: 'Points Against', type: 'number' }),
+                        defineField({ name: 'pointsDifference', title: 'Points Difference', type: 'number' }),
+                        defineField({ name: 'bonusPoints', title: 'Bonus Points', type: 'number' }),
+                        defineField({ name: 'totalPoints', title: 'Total Points', type: 'number' }),
+                    ],
+                    preview: {
+                        select: {
+                            pos: 'position',
+                            team: 'teamName',
+                            pool: 'pool',
+                            tp: 'totalPoints',
+                        },
+                        prepare({ pos, team, pool, tp }) {
+                            return {
+                                title: `${pos}. ${team || '(unknown team)'}`,
+                                subtitle: `${pool || '—'} · ${tp ?? 0} pts`,
+                            }
+                        },
+                    },
+                }),
+            ],
+        }),
+    ],
+    preview: {
+        select: {
+            season: 'seasonLabel',
+            division: 'divisionName',
+            cid: 'championshipId',
+            updated: 'lastUpdated',
+        },
+        prepare({ season, division, cid, updated }) {
+            const date = updated ? new Date(updated).toLocaleDateString() : 'never'
+            return {
+                title: `${division || 'Standings'} · ${season || ''}`.trim(),
+                subtitle: `Championship_ID=${cid} · updated ${date}`,
+            }
+        },
+    },
+    orderings: [
+        {
+            title: 'Season (newest first)',
+            name: 'seasonDesc',
+            by: [{ field: 'seasonLabel', direction: 'desc' }],
+        },
+    ],
+})

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/scrape-rugby?seasonId=27",
       "schedule": "0 3 * * 1"
+    },
+    {
+      "path": "/api/scrape-standings",
+      "schedule": "0 11 * * 1"
     }
   ]
 }


### PR DESCRIPTION
… site

- Added support for league championship and standings in the Sanity schema.
- Updated the homepage and results pages to display league standings and championship details.
- Enhanced the Upcoming Events component to include teams data.
- Implemented revalidation logic for league standings and championship updates.
- Introduced new API routes for scraping standings and playoff brackets.

This update lays the groundwork for displaying comprehensive league information across the site.